### PR TITLE
Add support for custom level numbers and names

### DIFF
--- a/src/css/midday.css
+++ b/src/css/midday.css
@@ -56,6 +56,8 @@
 .cm-s-midday span.cm-MESSAGE {color: orange;font-style:italic;}
 .cm-s-midday span.cm-LEVEL_NUMBER_VERB {color: #AE81FF;font-weight:bold;}
 .cm-s-midday span.cm-LEVEL_NUMBER {color: orange;font-style:italic;}
+.cm-s-midday span.cm-LEVEL_TITLE_VERB {color: #AE81FF;font-weight:bold;}
+.cm-s-midday span.cm-LEVEL_TITLE {color: orange;font-style:italic;}
 .cm-s-midday span.cm-METADATA {color: #493C2B;font-weight:bold;}
 .cm-s-midday span.cm-METADATATEXT {color: #A46422;font-style:italic;}
 

--- a/src/css/midday.css
+++ b/src/css/midday.css
@@ -54,6 +54,8 @@
 .cm-s-midday span.cm-COMMAND {color: #AE81FF;font-weight:bold;}
 .cm-s-midday span.cm-MESSAGE_VERB {color: #AE81FF;font-weight:bold;}
 .cm-s-midday span.cm-MESSAGE {color: orange;font-style:italic;}
+.cm-s-midday span.cm-LEVEL_NUMBER_VERB {color: #AE81FF;font-weight:bold;}
+.cm-s-midday span.cm-LEVEL_NUMBER {color: orange;font-style:italic;}
 .cm-s-midday span.cm-METADATA {color: #493C2B;font-weight:bold;}
 .cm-s-midday span.cm-METADATATEXT {color: #A46422;font-style:italic;}
 

--- a/src/css/midnight.css
+++ b/src/css/midnight.css
@@ -56,6 +56,8 @@
 .cm-s-midnight span.cm-COMMAND {color: #AE81FF;font-weight:bold;}
 .cm-s-midnight span.cm-MESSAGE_VERB {color: #AE81FF;font-weight:bold;}
 .cm-s-midnight span.cm-MESSAGE {color: orange;font-style:italic;}
+.cm-s-midnight span.cm-LEVEL_NUMBER_VERB {color: #AE81FF;font-weight:bold;}
+.cm-s-midnight span.cm-LEVEL_NUMBER {color: orange;font-style:italic;}
 .cm-s-midnight span.cm-METADATA {color: #AE81FF;font-weight:bold;}
 .cm-s-midnight span.cm-METADATATEXT {color: orange;font-style:italic;}
 

--- a/src/css/midnight.css
+++ b/src/css/midnight.css
@@ -58,6 +58,8 @@
 .cm-s-midnight span.cm-MESSAGE {color: orange;font-style:italic;}
 .cm-s-midnight span.cm-LEVEL_NUMBER_VERB {color: #AE81FF;font-weight:bold;}
 .cm-s-midnight span.cm-LEVEL_NUMBER {color: orange;font-style:italic;}
+.cm-s-midnight span.cm-LEVEL_TITLE_VERB {color: #AE81FF;font-weight:bold;}
+.cm-s-midnight span.cm-LEVEL_TITLE {color: orange;font-style:italic;}
 .cm-s-midnight span.cm-METADATA {color: #AE81FF;font-weight:bold;}
 .cm-s-midnight span.cm-METADATATEXT {color: orange;font-style:italic;}
 

--- a/src/js/codemirror/anyword-hint.js
+++ b/src/js/codemirror/anyword-hint.js
@@ -38,8 +38,7 @@
 			['title_color', 'blue'],
 			'throttle_movement',
 			['zoomscreen', 'WxH'],
-			'show_level_number',
-			'show_level_title',
+			['level_title_style', 'number_title'],
         ];
         const color_keywords = [ 'author_color', 'background_color', 'keyhint_color', 'text_color', 'title_color' ]
 

--- a/src/js/codemirror/anyword-hint.js
+++ b/src/js/codemirror/anyword-hint.js
@@ -254,6 +254,10 @@
 					{
 						candlists.push(['MESSAGE_VERB', 'message'])
 					}
+					if ('number'.indexOf(lineToCursor.trim()) === 0)
+					{
+						candlists.push(['LEVEL_NUMBER_VERB', 'number'])
+					}
 					break
                 default: //preamble
 					var lc = lineToCursor.toLowerCase()

--- a/src/js/codemirror/anyword-hint.js
+++ b/src/js/codemirror/anyword-hint.js
@@ -39,6 +39,7 @@
 			'throttle_movement',
 			['zoomscreen', 'WxH'],
 			['level_title_style', 'number_title'],
+			'hide_level_title_in_menu',
         ];
         const color_keywords = [ 'author_color', 'background_color', 'keyhint_color', 'text_color', 'title_color' ]
 

--- a/src/js/codemirror/anyword-hint.js
+++ b/src/js/codemirror/anyword-hint.js
@@ -38,6 +38,8 @@
 			['title_color', 'blue'],
 			'throttle_movement',
 			['zoomscreen', 'WxH'],
+			'show_level_number',
+			'show_level_title',
         ];
         const color_keywords = [ 'author_color', 'background_color', 'keyhint_color', 'text_color', 'title_color' ]
 

--- a/src/js/codemirror/anyword-hint.js
+++ b/src/js/codemirror/anyword-hint.js
@@ -258,6 +258,10 @@
 					{
 						candlists.push(['LEVEL_NUMBER_VERB', 'number'])
 					}
+					if ('title'.indexOf(lineToCursor.trim()) === 0)
+					{
+						candlists.push(['LEVEL_TITLE_VERB', 'title'])
+					}
 					break
                 default: //preamble
 					var lc = lineToCursor.toLowerCase()

--- a/src/js/compiler.js
+++ b/src/js/compiler.js
@@ -263,7 +263,7 @@ function levelFromString(state, level)
 	const backgroundlayer = state.backgroundlayer;
 	const backgroundid = state.backgroundid;
 	const backgroundLayerMask = state.layerMasks[backgroundlayer];
-	let o = new Level(level.number, level.width, level.grid.length, new Int32Array(level.width * level.grid.length * STRIDE_OBJ))
+	let o = new Level(level.number, level.title, level.width, level.grid.length, new Int32Array(level.width * level.grid.length * STRIDE_OBJ))
 	o.lineNumber = level.lineNumber
 	execution_context.resetCommands()
 
@@ -338,7 +338,9 @@ function levelsToArray(state)
 			if (level.grid.length === 0) // TODO: how could we get this result from the parser? If it's actually impossible, the whole loop could be simply a call to state.levels.map.
 				continue
 			if (!level.hasOwnProperty('number'))
-				level.number = levelNumber
+				level.number = '' + levelNumber
+			if (!level.hasOwnProperty('title'))
+				level.title = level.number
 			let o = levelFromString(state, level)
 			processedLevels.push(o)
 			++levelNumber

--- a/src/js/compiler.js
+++ b/src/js/compiler.js
@@ -258,6 +258,27 @@ function makeMaskFromGlyph(glyph)
 	return glyphmask;
 }
 
+function generateLevelTitle(level, style)
+{
+	switch (style) {
+		case 'number':
+			return 'Level ' + level.number
+			
+		case 'title':
+			return level.title
+		
+		case 'number_title':
+			if (level.title != level.number)
+				return 'Level ' + level.number + '\n' + level.title
+			else
+				return 'Level ' + level.number
+	
+		case 'none':
+		default:
+			return ''
+	}
+}
+
 function levelFromString(state, level)
 {
 	const backgroundlayer = state.backgroundlayer;
@@ -342,33 +363,20 @@ function levelsToArray(state)
 			if (!level.hasOwnProperty('title'))
 				level.title = level.number
 
-			if ('show_level_number' in state.metadata)
-			{
-				if ('show_level_title' in state.metadata)
-				{
-					processedLevels.push({
-						type: 'message',
-						message: 'Level ' + level.number + '\n' + level.title,
-						lineNumber: level.lineNumber,
-					})
-				}
-				else
-				{
-					processedLevels.push({
-						type: 'message',
-						message: 'Level ' + level.number,
-						lineNumber: level.lineNumber,
-					})
-				}
-			}
-			else if ('show_level_title' in state.metadata)
-			{
+			const titleStyle = (
+				level.titleStyle == 'default'
+				? state.metadata['level_title_style']
+				: level.titleStyle
+			)
+
+			const titleMessage = generateLevelTitle(level, titleStyle)
+
+			if (titleMessage)
 				processedLevels.push({
 					type: 'message',
-					message: level.title,
+					message: titleMessage,
 					lineNumber: level.lineNumber,
 				})
-			}
 
 			let o = levelFromString(state, level)
 			processedLevels.push(o)

--- a/src/js/compiler.js
+++ b/src/js/compiler.js
@@ -341,6 +341,35 @@ function levelsToArray(state)
 				level.number = '' + levelNumber
 			if (!level.hasOwnProperty('title'))
 				level.title = level.number
+
+			if ('show_level_number' in state.metadata)
+			{
+				if ('show_level_title' in state.metadata)
+				{
+					processedLevels.push({
+						type: 'message',
+						message: 'Level ' + level.number + '\n' + level.title,
+						lineNumber: level.lineNumber,
+					})
+				}
+				else
+				{
+					processedLevels.push({
+						type: 'message',
+						message: 'Level ' + level.number,
+						lineNumber: level.lineNumber,
+					})
+				}
+			}
+			else if ('show_level_title' in state.metadata)
+			{
+				processedLevels.push({
+					type: 'message',
+					message: level.title,
+					lineNumber: level.lineNumber,
+				})
+			}
+
 			let o = levelFromString(state, level)
 			processedLevels.push(o)
 			++levelNumber

--- a/src/js/compiler.js
+++ b/src/js/compiler.js
@@ -263,7 +263,7 @@ function levelFromString(state, level)
 	const backgroundlayer = state.backgroundlayer;
 	const backgroundid = state.backgroundid;
 	const backgroundLayerMask = state.layerMasks[backgroundlayer];
-	let o = new Level(level.width, level.grid.length, new Int32Array(level.width * level.grid.length * STRIDE_OBJ))
+	let o = new Level(level.number, level.width, level.grid.length, new Int32Array(level.width * level.grid.length * STRIDE_OBJ))
 	o.lineNumber = level.lineNumber
 	execution_context.resetCommands()
 
@@ -320,6 +320,7 @@ function levelsToArray(state)
 {
 	let levels = state.levels
 	let processedLevels = []
+	let levelNumber = 1;
 
 	for (var level of levels)
 	{
@@ -336,8 +337,11 @@ function levelsToArray(state)
 		{
 			if (level.grid.length === 0) // TODO: how could we get this result from the parser? If it's actually impossible, the whole loop could be simply a call to state.levels.map.
 				continue
+			if (!level.hasOwnProperty('number'))
+				level.number = levelNumber
 			let o = levelFromString(state, level)
 			processedLevels.push(o)
+			++levelNumber
 		}
 
 	}

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -44,7 +44,7 @@ function levelFromUnitTestString(str)
 	const lines = str.split('\n')
 	const height = lines.length - 1
 	const width = lines[0].split(',').length - 1
-	var lev = new Level(width, height, new Int32Array(width * height * STRIDE_OBJ))
+	var lev = new Level(0, width, height, new Int32Array(width * height * STRIDE_OBJ))
 	execution_context.resetCommands()
 	var masks = []
 	for (const [y, line] of lines.entries())

--- a/src/js/debug.js
+++ b/src/js/debug.js
@@ -44,7 +44,7 @@ function levelFromUnitTestString(str)
 	const lines = str.split('\n')
 	const height = lines.length - 1
 	const width = lines[0].split(',').length - 1
-	var lev = new Level(0, width, height, new Int32Array(width * height * STRIDE_OBJ))
+	var lev = new Level('0', '0', width, height, new Int32Array(width * height * STRIDE_OBJ))
 	execution_context.resetCommands()
 	var masks = []
 	for (const [y, line] of lines.entries())

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -299,7 +299,7 @@ function loadText(txt)
 	editor.setValue(txt)
 	setEditorClean()
 	state = introstate
-	level = new Level(5, 5, new Int32Array(0))
+	level = new Level(0, 5, 5, new Int32Array(0))
 	title_screen.makeTitle()
 	compile(-1, txt)
 	setPageTitle()

--- a/src/js/editor.js
+++ b/src/js/editor.js
@@ -299,7 +299,7 @@ function loadText(txt)
 	editor.setValue(txt)
 	setEditorClean()
 	state = introstate
-	level = new Level(0, 5, 5, new Int32Array(0))
+	level = new Level('0', '0', 5, 5, new Int32Array(0))
 	title_screen.makeTitle()
 	compile(-1, txt)
 	setPageTitle()

--- a/src/js/editor/error_messages.js
+++ b/src/js/editor/error_messages.js
@@ -58,7 +58,7 @@ const error_messages = { // actually also warning messages
 	object_in_multiple_layers: object_name => 'Object "' + object_name.toUpperCase() + '" appears in multiple collision layers. I ignored it, but you should fix this!',
 	// levels
 	non_rectangular_level: 'Maps must be rectangular, yo (In a level, the length of each row must be the same).',
-
+	long_level_number: 'Level numbers should not be longer than 10 characters to fit on the title screen'
 	// rule_parser.js
 	// ==============
 

--- a/src/js/editor/error_messages.js
+++ b/src/js/editor/error_messages.js
@@ -61,6 +61,7 @@ const error_messages = { // actually also warning messages
 	long_level_number: 'Level numbers should not be longer than 10 characters to fit on the title screen',
 	repeated_level_number: 'You\'ve already specified a number for this level. Overriding the previous number.',
 	repeated_level_title: 'You\'ve already specified a title for this level. Overriding the previous title.',
+	unknown_title_style: style => 'Unknown title style "' + style + '". Refer to the documentation for possible values.',
 	// rule_parser.js
 	// ==============
 

--- a/src/js/editor/error_messages.js
+++ b/src/js/editor/error_messages.js
@@ -58,7 +58,8 @@ const error_messages = { // actually also warning messages
 	object_in_multiple_layers: object_name => 'Object "' + object_name.toUpperCase() + '" appears in multiple collision layers. I ignored it, but you should fix this!',
 	// levels
 	non_rectangular_level: 'Maps must be rectangular, yo (In a level, the length of each row must be the same).',
-	long_level_number: 'Level numbers should not be longer than 10 characters to fit on the title screen',
+	long_level_number: 'Level numbers should not be longer than 10 characters to fit on the title screen.',
+	long_level_title: 'Long level title might get truncated on pause menu.',
 	repeated_level_number: 'You\'ve already specified a number for this level. Overriding the previous number.',
 	repeated_level_title: 'You\'ve already specified a title for this level. Overriding the previous title.',
 	unknown_title_style: style => 'Unknown title style "' + style + '". Refer to the documentation for possible values.',

--- a/src/js/editor/error_messages.js
+++ b/src/js/editor/error_messages.js
@@ -58,7 +58,9 @@ const error_messages = { // actually also warning messages
 	object_in_multiple_layers: object_name => 'Object "' + object_name.toUpperCase() + '" appears in multiple collision layers. I ignored it, but you should fix this!',
 	// levels
 	non_rectangular_level: 'Maps must be rectangular, yo (In a level, the length of each row must be the same).',
-	long_level_number: 'Level numbers should not be longer than 10 characters to fit on the title screen'
+	long_level_number: 'Level numbers should not be longer than 10 characters to fit on the title screen',
+	repeated_level_number: 'You\'ve already specified a number for this level. Overriding the previous number.',
+	repeated_level_title: 'You\'ve already specified a title for this level. Overriding the previous title.',
 	// rule_parser.js
 	// ==============
 

--- a/src/js/engine/level.js
+++ b/src/js/engine/level.js
@@ -1,8 +1,10 @@
 // uses: STRIDE_OBJ, STRIDE_MOV
 
 // levels are only constructed in engine/engine_base.js/unloadGame and compiler.js/levelFromString
-function Level(width, height, objects)
+function Level(number, width, height, objects)
 {
+	this.number = number
+	this.type = 'level'
 	// Definition of the level layout (should be constant)
 	this.width = width
 	this.height = height
@@ -13,7 +15,7 @@ function Level(width, height, objects)
 
 Level.prototype.clone = function()
 {
-	return new Level(this.width, this.height, new Int32Array(this.objects))
+	return new Level(this.number, this.width, this.height, new Int32Array(this.objects))
 }
 
 Level.prototype.cellCoord = function(cell_index)

--- a/src/js/engine/level.js
+++ b/src/js/engine/level.js
@@ -1,9 +1,10 @@
 // uses: STRIDE_OBJ, STRIDE_MOV
 
 // levels are only constructed in engine/engine_base.js/unloadGame and compiler.js/levelFromString
-function Level(number, width, height, objects)
+function Level(number, title, width, height, objects)
 {
 	this.number = number
+	this.title = title
 	this.type = 'level'
 	// Definition of the level layout (should be constant)
 	this.width = width
@@ -15,7 +16,7 @@ function Level(number, width, height, objects)
 
 Level.prototype.clone = function()
 {
-	return new Level(this.number, this.width, this.height, new Int32Array(this.objects))
+	return new Level(this.number, this.title, this.width, this.height, new Int32Array(this.objects))
 }
 
 Level.prototype.cellCoord = function(cell_index)

--- a/src/js/engine/message_screen.js
+++ b/src/js/engine/message_screen.js
@@ -215,7 +215,7 @@ MenuScreen.prototype.makePauseMenu = function()
 	const empty_line = [empty_terminal_line, state.fgcolor]
 	const level = getCurrentLevel()
 	this.text = [ empty_line, [centerText('-< GAME PAUSED >-'), state.titlecolor], [centerText('Level '+level.number), state.titlecolor] ]
-	if (level.title != level.number)
+	if (!('hide_level_title_in_menu' in state.metadata) && level.title != level.number)
 	{
 		let title = level.title
 		if (title.length > empty_terminal_line.length)

--- a/src/js/engine/message_screen.js
+++ b/src/js/engine/message_screen.js
@@ -108,6 +108,31 @@ function getLevelName(lvl = curlevel)
 	return result
 }
 
+function getLevelNumber(lvl = curlevel)
+{
+	// If this is called during a message, we return the number of the next level.
+	for (let i = lvl; i < state.levels.length; ++i)
+	{
+		if (state.levels[i].type === 'level')
+		{
+			return state.levels[i].number
+		}
+	}
+
+	// If this is called for a message after the final level, we instead return the
+	// number of the final level.
+	for (let i = lvl-1; i >= 0; --i)
+	{
+		if (state.levels[i].type === 'level')
+		{
+			return state.levels[i].number
+		}
+	}
+	
+	// Fallback for games without levels, I guess
+	return '1'
+}
+
 // sets: this.text
 MenuScreen.prototype.makeTitle = function()
 {
@@ -154,7 +179,7 @@ MenuScreen.prototype.makeTitle = function()
 	this.text.push( ...Array(author_bottomline - this.text.length).fill(empty_line) )
 
 	// Add menu options
-	this.makeMenuItems(3,  this.isContinuePossible() ? [['continue from level '+getLevelName(this.curlevel), () => this.titleMenuContinue()], ['new game', titleMenuNewGame]] : [['start', titleMenuNewGame]])
+	this.makeMenuItems(3,  this.isContinuePossible() ? [['continue from level '+getLevelNumber(this.curlevel), () => this.titleMenuContinue()], ['new game', titleMenuNewGame]] : [['start', titleMenuNewGame]])
 	this.text.push( empty_line )
 
 	// Add key configuration info:
@@ -199,7 +224,7 @@ function wordwrap(str, width = terminal_width)
 MenuScreen.prototype.makePauseMenu = function()
 {
 	const empty_line = [empty_terminal_line, state.fgcolor]
-	this.text = [ empty_line, [centerText('-< GAME PAUSED >-'), state.titlecolor], [centerText('Level '+getLevelName()), state.titlecolor], empty_line ]
+	this.text = [ empty_line, [centerText('-< GAME PAUSED >-'), state.titlecolor], [centerText('Level '+getLevelNumber()), state.titlecolor], empty_line ]
 	var menu_entries = [
 		['resume game', () => this.closeMenu()],
 		(screen_layout.content.screen_type === 'text') ? ['skip text', skipTextLevels] : ['replay level from the start', pauseMenuRestart],

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -23,6 +23,7 @@ for post-launch credits, check out activty on github.com/increpare/PuzzleScript
 const relativedirs = ['^', 'v', '<', '>', 'moving','stationary','parallel','perpendicular', 'no'];
 const logicWords = ['all', 'no', 'on', 'in', 'some'];
 const sectionNames = ['tags', 'objects', 'legend', 'sounds', 'collisionlayers', 'rules', 'winconditions', 'levels', 'mappings'];
+const titleStyles = ['default', 'none', 'number', 'title', 'number_title']
 
 const reg_commands = /(sfx0|sfx1|sfx2|sfx3|Sfx4|sfx5|sfx6|sfx7|sfx8|sfx9|sfx10|cancel|checkpoint|restart|win|message|again)\b/u;
 const reg_name = /[\p{Letter}\p{Number}_]+/u;
@@ -178,8 +179,8 @@ PuzzleScriptParser.prototype.logWarning = function(msg)
 
 //	------- METADATA --------
 
-const metadata_with_value = ['title','author','homepage','background_color','text_color','title_color','author_color','keyhint_color','key_repeat_interval','realtime_interval','again_interval','flickscreen','zoomscreen','color_palette','youtube', 'sprite_size']
-const metadata_without_value = ['run_rules_on_level_start','norepeat_action','require_player_movement','debug','verbose_logging','throttle_movement','noundo','noaction','norestart','show_level_number','show_level_title']
+const metadata_with_value = ['title','author','homepage','background_color','text_color','title_color','author_color','keyhint_color','key_repeat_interval','realtime_interval','again_interval','flickscreen','zoomscreen','color_palette','youtube', 'sprite_size','level_title_style']
+const metadata_without_value = ['run_rules_on_level_start','norepeat_action','require_player_movement','debug','verbose_logging','throttle_movement','noundo','noaction','norestart']
 
 PuzzleScriptParser.prototype.registerMetaData = function(key, value)
 {
@@ -403,8 +404,22 @@ PuzzleScriptParser.prototype.finalizePreamble = function()
 	}
 	else
 	{
-		this.metadata_keys.push('sprite_size')
-		this.metadata_values.push( [5, 5] )
+		this.registerMetaData('sprite_size', [5, 5])
+	}
+
+	const level_title_style_index = this.metadata_keys.indexOf('level_title_style')
+	if (level_title_style_index >= 0)
+	{
+		const level_title_style = this.metadata_values[level_title_style_index]
+		if (titleStyles.indexOf(level_title_style) < 0 || level_title_style == 'default')
+		{
+			this.logError(['unknown_title_style', level_title_style])
+			this.metadata_values[level_title_style_index] = 'none'
+		}
+	}
+	else
+	{
+		this.registerMetaData('level_title_style', 'none')
 	}
 }
 
@@ -1459,6 +1474,7 @@ PuzzleScriptParser.prototype.tokenInLevelsSection = function(is_start_of_line, s
 	// 4 = title
 	if (is_start_of_line)
 	{
+		let titleVerb
 		if (stream.match(/[\p{Separator}\s]*message\b[\p{Separator}\s]*/u, true))
 		{
 			this.tokenIndex = 2
@@ -1495,10 +1511,18 @@ PuzzleScriptParser.prototype.tokenInLevelsSection = function(is_start_of_line, s
 			lastLevel.number = levelNumber
 			return 'LEVEL_NUMBER_VERB'
 		}
-		else if (stream.match(/[\p{Separator}\s]*title\b[\p{Separator}\s]*/u, true))
+		else if (titleVerb = stream.match(/[\p{Separator}\s]*title\b(?::\w*)?[\p{Separator}\s]*/u, true))
 		{
 			this.tokenIndex = 4
-			let levelTitle = this.mixedCase.slice(stream.pos).trim()
+			const parts = titleVerb[0].trim().split(':')
+			let titleStyle = parts.length > 1 ? parts[1] : 'default'
+			if (titleStyles.indexOf(titleStyle) < 0)
+			{
+				this.logError(['unknown_title_style', titleStyle])
+				titleStyle = 'default'
+				return 'ERROR'
+			}
+			const levelTitle = this.mixedCase.slice(stream.pos).trim()
 			let lastLevel = this.levels[this.levels.length - 1]
 			if (lastLevel.type !== 'level' || lastLevel.grid.length > 0)
 			{
@@ -1508,6 +1532,7 @@ PuzzleScriptParser.prototype.tokenInLevelsSection = function(is_start_of_line, s
 			if (lastLevel.hasOwnProperty('title'))
 				this.logWarning(['repeated_level_title'])
 			lastLevel.title = levelTitle
+			lastLevel.titleStyle = titleStyle
 			return 'LEVEL_TITLE_VERB'
 		}
 		else

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -1456,6 +1456,7 @@ PuzzleScriptParser.prototype.tokenInLevelsSection = function(is_start_of_line, s
 	// 1 = level
 	// 2 = message
 	// 3 = number
+	// 4 = title
 	if (is_start_of_line)
 	{
 		if (stream.match(/[\p{Separator}\s]*message\b[\p{Separator}\s]*/u, true))
@@ -1484,14 +1485,30 @@ PuzzleScriptParser.prototype.tokenInLevelsSection = function(is_start_of_line, s
 			if (levelNumber.length > 10)
 				this.logWarning(['long_level_number'])
 			let lastLevel = this.levels[this.levels.length - 1]
-			if (lastLevel.type !== 'level' || lastLevel.grid !== [])
+			if (lastLevel.type !== 'level' || lastLevel.grid.length > 0)
 			{
 				lastLevel = {type: 'level', grid: [],}
 				this.levels.push(lastLevel)
 			}
+			if (lastLevel.hasOwnProperty('number'))
+				this.logWarning(['repeated_level_number'])
 			lastLevel.number = levelNumber
-			// TODO: add check on maximum string length
 			return 'LEVEL_NUMBER_VERB'
+		}
+		else if (stream.match(/[\p{Separator}\s]*title\b[\p{Separator}\s]*/u, true))
+		{
+			this.tokenIndex = 4
+			let levelTitle = this.mixedCase.slice(stream.pos).trim()
+			let lastLevel = this.levels[this.levels.length - 1]
+			if (lastLevel.type !== 'level' || lastLevel.grid.length > 0)
+			{
+				lastLevel = {type: 'level', grid: [],}
+				this.levels.push(lastLevel)
+			}
+			if (lastLevel.hasOwnProperty('title'))
+				this.logWarning(['repeated_level_title'])
+			lastLevel.title = levelTitle
+			return 'LEVEL_TITLE_VERB'
 		}
 		else
 		{
@@ -1537,6 +1554,7 @@ PuzzleScriptParser.prototype.tokenInLevelsSection = function(is_start_of_line, s
 			return [
 				'MESSAGE', // 2
 				'LEVEL_NUMBER', // 3
+				'LEVEL_TITLE', // 4
 			][this.tokenIndex - 2]
 		}
 	}

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -96,7 +96,7 @@ function PuzzleScriptParser()
 
 	this.winconditions = []
 
-	this.levels = [[]]
+	this.levels = [{type: 'level', grid: []}]
 }
 
 PuzzleScriptParser.prototype.copy = function()
@@ -137,7 +137,13 @@ PuzzleScriptParser.prototype.copy = function()
 
 	result.abbrevNames = this.abbrevNames.concat([])
 
-	result.levels = this.levels.map( i => i.concat([]) )
+	// TODO: replace this with structuredClone
+	result.levels = this.levels.map( level => { 
+		level = Object.assign({}, level)
+		if (level.hasOwnProperty('grid'))
+			level.grid = level.grid.concat([])
+		return level
+	})
 
 	result.STRIDE_OBJ = this.STRIDE_OBJ
 	result.STRIDE_MOV = this.STRIDE_MOV
@@ -307,9 +313,10 @@ PuzzleScriptParser.prototype.blankLine = function() // called when the line is e
 	}
 	else if (this.section === 'levels')
 	{
-		if (this.levels[this.levels.length - 1].length > 0)
+		let lastLevel = this.levels[this.levels.length - 1]
+		if (lastLevel.type !== 'level' || lastLevel.grid.length > 0)
 		{
-			this.levels.push([]);
+			this.levels.push({type: 'level', grid: []});
 		}
 	}
 }
@@ -325,7 +332,7 @@ PuzzleScriptParser.prototype.tokenInPreambleSection = function(is_start_of_line,
 	{
 		this.tokenIndex = 0;
 	}
-	else if (this.tokenIndex != 0) // we've already parsed the whole line, now we are necessiraly in the metadata value's text
+	else if (this.tokenIndex != 0) // we've already parsed the whole line, now we are necessarily in the metadata value's text
 	{
 		stream.match(reg_notcommentstart, true); // TODO: we probably want to read everything till the end of line instead, because comments should be forbiden on metadata lines as it prevents from putting parentheses in the metadata text...
 		return "METADATATEXT";
@@ -1449,32 +1456,46 @@ PuzzleScriptParser.prototype.tokenInLevelsSection = function(is_start_of_line, s
 	{
 		if (stream.match(/[\p{Separator}\s]*message\b[\p{Separator}\s]*/u, true))
 		{
-			this.tokenIndex = 1;//1/2 = message/level
-			var newdat = ['\n', this.mixedCase.slice(stream.pos).trim(), this.lineNumber];
-			if (this.levels[this.levels.length - 1].length == 0) {
-				this.levels.splice(this.levels.length - 1, 0, newdat);
-			} else {
-				this.levels.push(newdat);
+			this.tokenIndex = 1 // 1/2 = message/level
+			let messageData = {
+				type: 'message',
+				message: this.mixedCase.slice(stream.pos).trim(),
+				lineNumber: this.lineNumber,
 			}
-			return 'MESSAGE_VERB';
-		} else {
-			var line = stream.match(reg_notcommentstart, false)[0].trim();
-			this.tokenIndex = 2;
-			var lastlevel = this.levels[this.levels.length - 1];
-			if (lastlevel[0] == '\n') {
-				this.levels.push([this.lineNumber, line]);
+			let lastLevel = this.levels[this.levels.length - 1]
+			if (lastLevel.type === 'level' && lastLevel.grid.length === 0) {
+				this.levels.splice(this.levels.length - 1, 0, messageData)
 			} else {
-				if (lastlevel.length == 0)
+				this.levels.push(messageData)
+			}
+			return 'MESSAGE_VERB'
+		} else {
+			let line = stream.match(reg_notcommentstart, false)[0].trim()
+			this.tokenIndex = 2
+			let lastLevel = this.levels[this.levels.length - 1]
+			if (lastLevel.type !== 'level') {
+				this.levels.push({
+					type: 'level',
+					lineNumber: this.lineNumber,
+					grid: [line],
+					width: line.length,
+				})
+			} else {
+				if (!lastLevel.hasOwnProperty('lineNumber'))
 				{
-					lastlevel.push(this.lineNumber);
+					lastLevel.lineNumber = this.lineNumber
 				}
-				lastlevel.push(line);  
+				lastLevel.grid.push(line)
 
-				if (lastlevel.length > 1) 
+				if (lastLevel.hasOwnProperty('width')) 
 				{
-					if (line.length != lastlevel[1].length) {
+					if (line.length != lastLevel.width) {
 						this.logWarning(['non_rectangular_level'])
 					}
+				}
+				else
+				{
+					lastLevel.width = line.length
 				}
 			}
 			
@@ -1484,14 +1505,14 @@ PuzzleScriptParser.prototype.tokenInLevelsSection = function(is_start_of_line, s
 	{
 		if (this.tokenIndex == 1)
 		{
-			stream.skipToEnd();
-			return 'MESSAGE';
+			stream.skipToEnd()
+			return 'MESSAGE'
 		}
 	}
 
 	if (this.tokenIndex === 2 && !stream.eol())
 	{
-		var ch = stream.peek()
+		let ch = stream.peek()
 		stream.next()
 		return (this.abbrevNames.indexOf(ch) >= 0) ? 'LEVEL' : 'ERROR'
 		// if (this.abbrevNames.indexOf(ch) >= 0)

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -1484,7 +1484,7 @@ PuzzleScriptParser.prototype.tokenInLevelsSection = function(is_start_of_line, s
 			if (levelNumber.length > 10)
 				this.logWarning(['long_level_number'])
 			let lastLevel = this.levels[this.levels.length - 1]
-			if (lastLevel.type !== 'level')
+			if (lastLevel.type !== 'level' || lastLevel.grid !== [])
 			{
 				lastLevel = {type: 'level', grid: [],}
 				this.levels.push(lastLevel)

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -1452,35 +1452,63 @@ PuzzleScriptParser.prototype.tokenInWinconditionsSection = function(is_start_of_
 
 PuzzleScriptParser.prototype.tokenInLevelsSection = function(is_start_of_line, stream, ch)
 {
+	// Token indices:
+	// 1 = level
+	// 2 = message
+	// 3 = number
 	if (is_start_of_line)
 	{
 		if (stream.match(/[\p{Separator}\s]*message\b[\p{Separator}\s]*/u, true))
 		{
-			this.tokenIndex = 1 // 1/2 = message/level
+			this.tokenIndex = 2
 			let messageData = {
 				type: 'message',
 				message: this.mixedCase.slice(stream.pos).trim(),
 				lineNumber: this.lineNumber,
 			}
 			let lastLevel = this.levels[this.levels.length - 1]
-			if (lastLevel.type === 'level' && lastLevel.grid.length === 0) {
+			if (lastLevel.type === 'level' && lastLevel.grid.length === 0)
+			{
 				this.levels.splice(this.levels.length - 1, 0, messageData)
-			} else {
+			}
+			else
+			{
 				this.levels.push(messageData)
 			}
 			return 'MESSAGE_VERB'
-		} else {
-			let line = stream.match(reg_notcommentstart, false)[0].trim()
-			this.tokenIndex = 2
+		}
+		else if (stream.match(/[\p{Separator}\s]*number\b[\p{Separator}\s]*/u, true))
+		{
+			this.tokenIndex = 3
+			let levelNumber = this.mixedCase.slice(stream.pos).trim()
+			if (levelNumber.length > 10)
+				this.logWarning(['long_level_number'])
 			let lastLevel = this.levels[this.levels.length - 1]
-			if (lastLevel.type !== 'level') {
+			if (lastLevel.type !== 'level')
+			{
+				lastLevel = {type: 'level', grid: [],}
+				this.levels.push(lastLevel)
+			}
+			lastLevel.number = levelNumber
+			// TODO: add check on maximum string length
+			return 'LEVEL_NUMBER_VERB'
+		}
+		else
+		{
+			let line = stream.match(reg_notcommentstart, false)[0].trim()
+			this.tokenIndex = 1
+			let lastLevel = this.levels[this.levels.length - 1]
+			if (lastLevel.type !== 'level')
+			{
 				this.levels.push({
 					type: 'level',
 					lineNumber: this.lineNumber,
 					grid: [line],
 					width: line.length,
 				})
-			} else {
+			}
+			else
+			{
 				if (!lastLevel.hasOwnProperty('lineNumber'))
 				{
 					lastLevel.lineNumber = this.lineNumber
@@ -1498,19 +1526,22 @@ PuzzleScriptParser.prototype.tokenInLevelsSection = function(is_start_of_line, s
 					lastLevel.width = line.length
 				}
 			}
-			
 		}
 	}
 	else
 	{
-		if (this.tokenIndex == 1)
+		if (this.tokenIndex > 1)
 		{
 			stream.skipToEnd()
-			return 'MESSAGE'
+			
+			return [
+				'MESSAGE', // 2
+				'LEVEL_NUMBER', // 3
+			][this.tokenIndex - 2]
 		}
 	}
 
-	if (this.tokenIndex === 2 && !stream.eol())
+	if (this.tokenIndex === 1 && !stream.eol())
 	{
 		let ch = stream.peek()
 		stream.next()

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -1514,6 +1514,7 @@ PuzzleScriptParser.prototype.tokenInLevelsSection = function(is_start_of_line, s
 		else if (titleVerb = stream.match(/[\p{Separator}\s]*title\b(?::\w*)?[\p{Separator}\s]*/u, true))
 		{
 			this.tokenIndex = 4
+			
 			const parts = titleVerb[0].trim().split(':')
 			let titleStyle = parts.length > 1 ? parts[1] : 'default'
 			if (titleStyles.indexOf(titleStyle) < 0)
@@ -1522,7 +1523,11 @@ PuzzleScriptParser.prototype.tokenInLevelsSection = function(is_start_of_line, s
 				titleStyle = 'default'
 				return 'ERROR'
 			}
+
 			const levelTitle = this.mixedCase.slice(stream.pos).trim()
+			if (levelTitle.length > 34)
+				this.logWarning(['long_level_title'])
+
 			let lastLevel = this.levels[this.levels.length - 1]
 			if (lastLevel.type !== 'level' || lastLevel.grid.length > 0)
 			{

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -179,7 +179,7 @@ PuzzleScriptParser.prototype.logWarning = function(msg)
 //	------- METADATA --------
 
 const metadata_with_value = ['title','author','homepage','background_color','text_color','title_color','author_color','keyhint_color','key_repeat_interval','realtime_interval','again_interval','flickscreen','zoomscreen','color_palette','youtube', 'sprite_size']
-const metadata_without_value = ['run_rules_on_level_start','norepeat_action','require_player_movement','debug','verbose_logging','throttle_movement','noundo','noaction','norestart']
+const metadata_without_value = ['run_rules_on_level_start','norepeat_action','require_player_movement','debug','verbose_logging','throttle_movement','noundo','noaction','norestart','show_level_number','show_level_title']
 
 PuzzleScriptParser.prototype.registerMetaData = function(key, value)
 {

--- a/src/js/parser.js
+++ b/src/js/parser.js
@@ -180,7 +180,7 @@ PuzzleScriptParser.prototype.logWarning = function(msg)
 //	------- METADATA --------
 
 const metadata_with_value = ['title','author','homepage','background_color','text_color','title_color','author_color','keyhint_color','key_repeat_interval','realtime_interval','again_interval','flickscreen','zoomscreen','color_palette','youtube', 'sprite_size','level_title_style']
-const metadata_without_value = ['run_rules_on_level_start','norepeat_action','require_player_movement','debug','verbose_logging','throttle_movement','noundo','noaction','norestart']
+const metadata_without_value = ['run_rules_on_level_start','norepeat_action','require_player_movement','debug','verbose_logging','throttle_movement','noundo','noaction','norestart','hide_level_title_in_menu']
 
 PuzzleScriptParser.prototype.registerMetaData = function(key, value)
 {
@@ -1525,7 +1525,7 @@ PuzzleScriptParser.prototype.tokenInLevelsSection = function(is_start_of_line, s
 			}
 
 			const levelTitle = this.mixedCase.slice(stream.pos).trim()
-			if (levelTitle.length > 34)
+			if (this.metadata_keys.indexOf('hide_level_title_in_menu') < 0 && levelTitle.length > 34)
 				this.logWarning(['long_level_title'])
 
 			let lastLevel = this.levels[this.levels.length - 1]


### PR DESCRIPTION
Adds syntax to specify custom numbers and names for levels, which are then used in menus and can be displayed in automatically generated messages before each level.

- [x] Refactor parser to return more structured data from the level section (instead of just lists with magic first items to identify the type).
- [x] Add syntax for specifying level numbers.
- [x] Add syntax for specifying level names.
- [x] Display level numbers in menus.
- [x] Add prelude options to generate messages from numbers or names.